### PR TITLE
Added zoom buttons to the Blockly workspace

### DIFF
--- a/library/index.js
+++ b/library/index.js
@@ -1,4 +1,14 @@
-var workspace = Blockly.inject('blocklyDiv',{toolbox: document.getElementById('toolbox')}); // assign a var to the blockly workspace for future adressing
+var workspace = Blockly.inject('blocklyDiv',
+										   {toolbox: document.getElementById('toolbox'),
+											zoom:
+											{controls:true,
+											 wheel:true,
+											 startScale: 1.0,
+											 maxScale: 3,
+											 minScale: 0.3,
+											 scaleSpeed:1.2},
+											trashcan: true}); 
+// [above] inject the blockly workspace into the div
 function onUpdate(event){
   var code = htmlGen.workspaceToCode(workspace);
   var iframe = document.getElementById('preview-frame');


### PR DESCRIPTION
Makes it more convenient to navigate larger blocks of code.
![image](https://user-images.githubusercontent.com/22198767/34468541-226e5a20-ef03-11e7-8712-358c9b3598dd.png)
The 'target' shaped button resets all views and zoom.