### PR TITLE
Fixed bug #47. The workspace needs to be declared first, before init.

### DIFF
--- a/library/index.js
+++ b/library/index.js
@@ -1,11 +1,3 @@
-(function(){
-  "use strict";
-  Blockly.JavaScript.init(workspace);
-}());
-var editor = ace.edit("code-output");
-editor.setTheme("ace/theme/textmate");
-editor.session.setMode("ace/mode/html");
-editor.setReadOnly(true);
 var workspace = Blockly.inject('blocklyDiv',
 										   {toolbox: document.getElementById('toolbox'),
 											zoom:
@@ -16,6 +8,15 @@ var workspace = Blockly.inject('blocklyDiv',
 											 minScale: 0.3,
 											 scaleSpeed:1.2},
 											trashcan: true});
+(function(){
+  "use strict";
+  Blockly.JavaScript.init(workspace);
+}());
+var editor = ace.edit("code-output");
+editor.setTheme("ace/theme/textmate");
+editor.session.setMode("ace/mode/html");
+editor.setReadOnly(true);
+
 // [above] inject the blockly workspace into the div
 function onUpdate(event){
   var code = htmlGen.workspaceToCode(workspace);


### PR DESCRIPTION
Fixed bug #47 .
The workspace had been initiated:
`
(function(){
  "use strict";
  Blockly.JavaScript.init(workspace);
}());
`
before the variable `workspace` had been declared.